### PR TITLE
Clean cache on disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,14 @@ When constructing Fraudster you can pass an optional `options` object to enable 
             warnOnUnregistered: true,
             errorOnUnregistered: true,
             warnOnReplace: true,
-            errorOnReplace: true
+            errorOnReplace: true,
+            cleanCacheOnDisable: true // default false
         });
 
 If warn is enabled a warning will be logged to the console, if error is enabled an Error will be thrown
+
+When `cleanCacheOnDisable` is true the modules that were required while fraudster was enabled
+will be removed from cache on disable/deregisterAll
 
 ## Registering mocks
 
@@ -102,5 +106,3 @@ or
 If you just want to destoy all the things you can use the `deregisterAll` method
 
     fraudster.deregisterAll();
-
-

--- a/tests/fake-module.js
+++ b/tests/fake-module.js
@@ -1,0 +1,3 @@
+var fs = require('fs');
+
+module.exports = fs;

--- a/tests/index.js
+++ b/tests/index.js
@@ -121,3 +121,46 @@ test('Fraudster double enable / disable is ok is ok', function (t) {
 
     t.pass('didnt go bang');
 });
+
+test('Fraudster mocked dependencies still cached after disable', function (t) {
+    t.plan(2);
+    var fraudster = new Fraudster({cleanCacheOnDisable: false}),
+        mockedFs = 'Mocked fs',
+        fakeModule1, fakeModule2;
+
+    fraudster.registerMock('fs', mockedFs);
+
+    fraudster.enable();
+
+    fakeModule1 = require('./fake-module');
+
+    t.equal(fakeModule1, mockedFs, 'mock was correct');
+
+    fraudster.disable();
+
+    fakeModule2 = require('./fake-module');
+
+    t.equal(fakeModule2, mockedFs, 'mock still in cache after disable');
+});
+
+test('Fraudster clean modules from cache on disable', function (t) {
+    t.plan(2);
+    var fraudster = new Fraudster({cleanCacheOnDisable: true}),
+        original = require('fs'),
+        mockedFs = 'Mocked fs',
+        fakeModule1, fakeModule2;
+
+    fraudster.registerMock('fs', mockedFs);
+
+    fraudster.enable();
+
+    fakeModule1 = require('./fake-module');
+
+    t.equal(fakeModule1, mockedFs, 'mock was correct');
+
+    fraudster.disable();
+
+    fakeModule2 = require('./fake-module');
+
+    t.equal(fakeModule2, original, 'module was removed from cache');
+});


### PR DESCRIPTION
Hi @MauriceButler,

I implemented this functionality because I have had some issues with the cache that Node.js implements.

Those issues happen when you have a module `a.js` that requires another module e.g. `fs` and you need to mock that module (`fs`). The mock functionality works well but when `fraudster` is disabled and you require the `a.js` module for second time it is returned from `require.cache` which have his dependency `fs` still mocked. So with this when `fraudster` was instantiated with `cleanCacheOnDisable = true` option, the cache of the modules that were required while fraudster was enabled will be removed on `disable/deregisterAll`.

Cheers!
